### PR TITLE
Feat/logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
 gem "bunny", "~> 2.20.3"
+gem "colorize", "~> 0.8.1"
 gem "docker-api", "~> 2.2.0"
 gem "dry-schema", "~> 1.13.0"
+gem "i18n", "~> 1.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     bunny (2.20.3)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
+    colorize (0.8.1)
     concurrent-ruby (1.2.0)
     docker-api (2.2.0)
       excon (>= 0.47.0)
@@ -36,6 +37,8 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     excon (0.99.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     multi_json (1.15.0)
     rbtree (0.4.6)
     set (1.0.3)
@@ -49,8 +52,10 @@ PLATFORMS
 
 DEPENDENCIES
   bunny (~> 2.20.3)
+  colorize (~> 0.8.1)
   docker-api (~> 2.2.0)
   dry-schema (~> 1.13.0)
+  i18n (~> 1.12.0)
 
 BUNDLED WITH
    2.4.5

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,8 @@
 require "bunny"
+require "colorize"
 require "dry/schema"
+require "logger"
+require "i18n"
 
 require_relative "./models/executor"
 require_relative "./models/command"
@@ -8,6 +11,15 @@ require_relative "./models/task"
 require_relative "./models/pipeline"
 require_relative "./schemas/pipeline"
 
+VERSION = "0.1.0"
+
+I18n.load_path += Dir[File.expand_path("config/locales") + "/*.yml"]
+I18n.default_locale = :en
+
+$logger = Logger.new(STDOUT)
+$logger.info(I18n.t("app.started", version: VERSION))
+
 input = YAML.load(File.read("tests/input.yml"))
 pipeline = Pipeline.new(input)
+$logger.info(I18n.t("pipeline.loaded", name: pipeline.name))
 pipeline.start!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,29 @@
+en:
+  app:
+    started: Lucid Runner started (v%{version})
+  pipeline:
+    loaded: >-
+      New pipeline loaded: 
+      %{name}
+    starting: >-
+      Pipeline is starting: 
+      %{name}
+  docker:
+    container:
+      starting: >-
+        Container is starting (base %{base}) with
+        name %{container_name}.
+      started: >-
+        Container started:
+        %{container_name}
+      cleaning: >-
+        Container %{container_name} 
+        is being cleaned...
+      cleaned: >-
+        Container %{container_name} has
+        been cleaned.
+  task:
+    executing: >-
+      Task %{name} starting...
+    executed: >-
+      Task %{name} executed.

--- a/executors/docker.rb
+++ b/executors/docker.rb
@@ -3,32 +3,56 @@ require "securerandom"
 
 class DockerExecutor
   def initialize(base_image)
+    @container_name = SecureRandom.uuid.to_s
+
+    $logger.info(I18n.t(
+      "docker.container.starting",
+      base: base_image,
+      container_name: @container_name
+    ))
+
     @container = Docker::Container
       .create(
-        "Name" => SecureRandom.uuid.to_s,
+        "Name" => @container_name,
         "Image" => base_image,
         "Cmd" => [""]
       )
     
     @container.start
-    @container.exec(["ps", "aux"])
+    $logger.info(I18n.t(
+      "docker.container.started",
+      container_name: @container_name
+    ))
 
     self
   end
 
   def execute!(tasks)
     tasks.each do |task|
+      $logger.warn(I18n.t("task.executing", name: task.name))
       task.commands.each do |command|
         @container.exec(command.with_sh, tty: true, stdout: true) do |stream|
-          puts stream
+          $logger.debug(stream.chomp.colorize(:yellow))
         end
+        command.status = :done
       end
+      $logger.info(I18n.t("task.executed", name: task.name))
     end
   end
 
   def clean!
     if @container
+      $logger.info(I18n.t(
+        "docker.container.cleaning",
+        container_name: @container_name
+      ))
+
       @container.delete(force: true)
+
+      $logger.info(I18n.t(
+        "docker.container.cleaned",
+        container_name: @container_name
+      ))
     end
   end
 end

--- a/models/command.rb
+++ b/models/command.rb
@@ -1,4 +1,6 @@
 class Command
+  attr_accessor :status
+
   def initialize(command)
     @raw = command
     @status = :awaiting
@@ -10,15 +12,5 @@ class Command
       "-c",
       @raw
     ]
-  end
-
-  def run(executor)
-    begin
-      executor.execute!(raw)
-      @status = :done
-    rescue => exp
-      @status = :failed
-      @error = exp.to_s
-    end
   end
 end

--- a/models/executor.rb
+++ b/models/executor.rb
@@ -5,6 +5,8 @@ class Executor
   attr_accessor :runner
 
   def initialize(executor, base_image)
-    @runner = DockerExecutor.new(base_image)
+    if executor.eql?("docker")
+      @runner = DockerExecutor.new(base_image)
+    end
   end
 end

--- a/models/pipeline.rb
+++ b/models/pipeline.rb
@@ -1,4 +1,6 @@
 class Pipeline
+  attr_reader :name
+
   def initialize(input)
     schema = PipelineSchema.(input)
     @name = schema[:name]
@@ -29,6 +31,7 @@ class Pipeline
   end
 
   def start!
+    $logger.info(I18n.t("pipeline.starting", name: @name))
     tasks = ordered_tasks
     begin
       @executor.runner.execute!(tasks)

--- a/models/task.rb
+++ b/models/task.rb
@@ -1,6 +1,5 @@
 class Task
-  attr_reader :depends_on
-  attr_reader :commands
+  attr_reader :name, :depends_on, :commands
 
   def initialize(task_schema)
     @schema = task_schema


### PR DESCRIPTION
Uses i18n, colorize and Logger to write down logs during the execution.

```
bundler exec ruby app.rb 
I, [2023-02-18T22:57:34.201241 #108123]  INFO -- : Lucid Runner started (v0.1.0)
I, [2023-02-18T22:57:34.206325 #108123]  INFO -- : Container is starting (base base/alpine-3.14) with name 5031736c-a54c-45ac-bdec-642953832b79.
I, [2023-02-18T22:57:34.745364 #108123]  INFO -- : Container started: 5031736c-a54c-45ac-bdec-642953832b79
I, [2023-02-18T22:57:34.745542 #108123]  INFO -- : New pipeline loaded:  Test pipeline
I, [2023-02-18T22:57:34.745709 #108123]  INFO -- : Pipeline is starting:  Test pipeline
W, [2023-02-18T22:57:34.745902 #108123]  WARN -- : Task first test task starting...
D, [2023-02-18T22:57:34.833591 #108123] DEBUG -- : first
I, [2023-02-18T22:57:34.836143 #108123]  INFO -- : Task first test task executed.
W, [2023-02-18T22:57:34.838336 #108123]  WARN -- : Task second test task starting...
D, [2023-02-18T22:57:34.938110 #108123] DEBUG -- : second
I, [2023-02-18T22:57:34.939601 #108123]  INFO -- : Task second test task executed.
I, [2023-02-18T22:57:34.939771 #108123]  INFO -- : Container 5031736c-a54c-45ac-bdec-642953832b79  is being cleaned...
I, [2023-02-18T22:57:35.185538 #108123]  INFO -- : Container 5031736c-a54c-45ac-bdec-642953832b79 has been cleaned.
```