### PR TITLE
Feat/ignore

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,9 @@ en:
         been cleaned.
   task:
     executing: >-
-      Task %{name} starting...
+      Task `%{name}` starting...
     executed: >-
-      Task %{name} executed.
+      Task `%{name}` executed.
+    failed: >-
+      Task `%{name}` failed and result 
+      not ignored.

--- a/models/task.rb
+++ b/models/task.rb
@@ -1,6 +1,7 @@
 class Task
   attr_reader :name, :depends_on, :commands
-
+  attr_reader :ignore_fail
+  
   def initialize(task_schema)
     @schema = task_schema
     @name = task_schema[:name]

--- a/tests/input.yml
+++ b/tests/input.yml
@@ -5,9 +5,10 @@ base: base/alpine-3.14
 
 tasks:
   - name: first test task
-    ignore_fail: true
+    ignore_fail: false
     commands:
       - echo "first"
+      - exit 1
   
   - name: second test task
     depends_on:


### PR DESCRIPTION
Failing commands should stop a pipeline execution by default but adding `ignore_fail: true` as a task parameter should make the execution ignore exit codes other than 0.


```yaml
tasks:
  - name: first test task
    ignore_fail: true
    commands:
      - echo "first"
      - exit 1
```